### PR TITLE
fix: resolve dependabot vulnerability alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 screen-brightness-control==0.14.0
-requests==2.32.0
+requests==2.33.0
 astral==3.2
 pystray==0.19.4
-Pillow==11.1.0
+Pillow==12.2.0


### PR DESCRIPTION
## Summary
- Bump `Pillow` from 11.1.0 to 12.2.0 (fixes FITS GZIP decompression bomb and OOB write on PSD load)
- Bump `requests` from 2.32.0 to 2.33.0 (fixes insecure temp file reuse and .netrc credential leak)

Resolves dependabot alerts #7, #8, #9, #10.

## Test plan
- [ ] Verify no import errors with updated packages
- [ ] Confirm brightness control functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)